### PR TITLE
Add basic syntax highlight to CLI output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,9 +57,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "tutara-cli"
 version = "0.0.0"
 dependencies = [
+ "termcolor",
  "tutara-interpreter",
 ]
 
@@ -134,3 +144,34 @@ name = "wasm-bindgen-shared"
 version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/tutara-cli/Cargo.toml
+++ b/tutara-cli/Cargo.toml
@@ -7,3 +7,4 @@ default-run = "tutara-cli"
 
 [dependencies]
 tutara-interpreter = { path = "../tutara-interpreter" }
+termcolor = "1.1"

--- a/tutara-interpreter/src/tokenizer/tokenize.rs
+++ b/tutara-interpreter/src/tokenizer/tokenize.rs
@@ -30,6 +30,7 @@ impl Iterator for Tokenizer<'_> {
 					if current == '\n' {
 						self.line += 1;
 						self.column = 0;
+						self.length = 0;
 					}
 				} else if current.is_digit(10) {
 					token = Some(self.number(current));
@@ -170,9 +171,9 @@ impl Tokenizer<'_> {
 				} else if *next == '\'' {
 					// string end
 					self.chars.next();
+					self.length += 1;
 					break;
 				} else if *next == '\n' {
-					// ERROR NO NEW LINE I NSTRING Pl0X
 					return self.create_error(
 						ErrorType::Lexical,
 						"Unexpected new line, expected end of string.".to_string(),


### PR DESCRIPTION
<!-- Use a short to the point title in the imperative form (Add foo, Update bar) -->

## Changes
The output of the CLI now uses colors to highlight the inputted code. This is an alternative to the big token table. In theory we could identify issues in the tokenizer by looking at the colors.

I found some small problems in the tokenizer where the column/line/length was not valid - those are fixed too.

### Screenshots

Looks like this:
![image](https://user-images.githubusercontent.com/2305178/97317891-98db2c80-186b-11eb-90a8-d9163802aca8.png) ![image](https://user-images.githubusercontent.com/2305178/97317916-9d074a00-186b-11eb-8e4a-3f246669feb3.png)


## Issues
<!-- 
Mention any issues that this PR resolves here.
Example: Fixes #13 or Part of #37
-->

## Additional information
<!-- Append additional documentation or other helpful information for reviewers. -->
