### PR TITLE
Resolve comment bug

### DIFF
--- a/tutara-interpreter/src/tokenizer/tokenizer.rs
+++ b/tutara-interpreter/src/tokenizer/tokenizer.rs
@@ -41,6 +41,7 @@ impl Iterator for Tokenizer<'_> {
 					token = Some(self.string());
 				} else if current == '/' && self.chars.peek() == Some(&'/') {
 					self.chars.next();
+					self.length += 1;
 
 					token = Some(self.comment());
 				} else if let Some(r#type) = TokenType::get_reserved_token(&current.to_string()) {


### PR DESCRIPTION
## Changes
The length of the comments was 1 to short because the tokenizer didn't account for one of the slashes

## Issues
None

## Additional information
None
