### PR TITLE
Build webassembly create in CI

### DIFF
--- a/.github/workflows/wasm-pack.yml
+++ b/.github/workflows/wasm-pack.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches: 
+      - master
 
 jobs:
   build:
@@ -24,6 +27,15 @@ jobs:
           rm -v pkg/.gitignore pkg/package.json
       - name: Upload WebAssembly package
         uses: actions/upload-artifact@v2
+        with:
+          name: WebAssembly package
+          path: ./tutara/tutara-wasm/pkg/
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    if: success() && github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/download-artifact@v2
         with:
           name: WebAssembly package
           path: ./tutara/tutara-wasm/pkg/


### PR DESCRIPTION
## Changes

- Builds the tutara-wasm crate in CI using wasm-pack
- Only publishes on master

Workflow is similar to the website repository for build+publish configuration.
